### PR TITLE
fix the @@excluded_environments init

### DIFF
--- a/lib/sidekiq_mailer.rb
+++ b/lib/sidekiq_mailer.rb
@@ -4,6 +4,7 @@ require 'sidekiq_mailer/proxy'
 
 module Sidekiq
   module Mailer
+    @@excluded_environments = []
     def self.excluded_environments=(envs)
       @@excluded_environments = [*envs].map { |e| e && e.to_sym }
     end

--- a/lib/sidekiq_mailer.rb
+++ b/lib/sidekiq_mailer.rb
@@ -4,13 +4,13 @@ require 'sidekiq_mailer/proxy'
 
 module Sidekiq
   module Mailer
-    @@excluded_environments = []
+    @@excluded_environments = nil
     def self.excluded_environments=(envs)
       @@excluded_environments = [*envs].map { |e| e && e.to_sym }
     end
 
     def self.excluded_environments
-      @@excluded_environments
+      @@excluded_environments ||= []
     end
 
     def self.current_env

--- a/sidekiq_mailer.gemspec
+++ b/sidekiq_mailer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::Mailer::VERSION
 
-  gem.add_dependency("activesupport", "~> 3.0")
-  gem.add_dependency("actionmailer", "~> 3.0")
+  gem.add_dependency("activesupport", ">= 3.0")
+  gem.add_dependency("actionmailer", ">= 3.0")
   gem.add_dependency("sidekiq", "~> 2.3")
 end

--- a/sidekiq_mailer.gemspec
+++ b/sidekiq_mailer.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = Sidekiq::Mailer::VERSION
 
-  gem.add_dependency("activesupport", ">= 3.0")
-  gem.add_dependency("actionmailer", ">= 3.0")
+  gem.add_dependency("activesupport", "~> 3.0")
+  gem.add_dependency("actionmailer", "~> 3.0")
   gem.add_dependency("sidekiq", "~> 2.3")
 end

--- a/test/sidekiq_mailer_test.rb
+++ b/test/sidekiq_mailer_test.rb
@@ -27,7 +27,6 @@ end
 
 class SidekiqMailerTest < Test::Unit::TestCase
   def setup
-    Sidekiq::Mailer.excluded_environments = []
     ActionMailer::Base.deliveries.clear
     Sidekiq::Mailer::Worker.jobs.clear
   end

--- a/test/sidekiq_mailer_test.rb
+++ b/test/sidekiq_mailer_test.rb
@@ -27,6 +27,7 @@ end
 
 class SidekiqMailerTest < Test::Unit::TestCase
   def setup
+    Sidekiq::Mailer.excluded_environments = []
     ActionMailer::Base.deliveries.clear
     Sidekiq::Mailer::Worker.jobs.clear
   end


### PR DESCRIPTION
Just init the class variable to avoid raising :

```
NameError - uninitialized class variable @@excluded_environments in Sidekiq::Mailer:
```
