### PR TITLE
Using #deliver instead of #deliver! on Mail::Message to respect interceptors.

### DIFF
--- a/lib/sidekiq_mailer/proxy.rb
+++ b/lib/sidekiq_mailer/proxy.rb
@@ -21,7 +21,7 @@ class Sidekiq::Mailer::Proxy
   end
 
   def deliver!
-    actual_message.deliver!
+    actual_message.deliver
   end
 
   def method_missing(method_name, *args)

--- a/test/sidekiq_mailer_test.rb
+++ b/test/sidekiq_mailer_test.rb
@@ -31,6 +31,16 @@ class MailerInAnotherQueue < ActionMailer::Base
   end
 end
 
+class PreventSomeEmails
+  def self.delivering_email(message)
+    if message.to.include?("foo@example.com")
+      message.perform_deliveries = false
+    end
+  end
+end
+
+ActionMailer::Base.register_interceptor(PreventSomeEmails)
+
 class SidekiqMailerTest < Test::Unit::TestCase
   def setup
     Sidekiq::Mailer.excluded_environments = []
@@ -39,50 +49,60 @@ class SidekiqMailerTest < Test::Unit::TestCase
   end
 
   def test_queue_a_new_job
-    BasicMailer.hi('test@test.com', 'Tester').deliver
+    BasicMailer.hi('test@example.com', 'Tester').deliver
 
     job_args = Sidekiq::Mailer::Worker.jobs.first['args']
-    expected_args = ['BasicMailer', 'hi', ['test@test.com', 'Tester']]
+    expected_args = ['BasicMailer', 'hi', ['test@example.com', 'Tester']]
     assert_equal expected_args, job_args
   end
 
   def test_queues_at_mailer_queue_by_default
-    BasicMailer.welcome('test@test.com').deliver
+    BasicMailer.welcome('test@example.com').deliver
     assert_equal 'mailer', Sidekiq::Mailer::Worker.jobs.first['queue']
   end
 
   def test_default_sidekiq_options
-    BasicMailer.welcome('test@test.com').deliver
+    BasicMailer.welcome('test@example.com').deliver
     assert_equal 'mailer', Sidekiq::Mailer::Worker.jobs.first['queue']
     assert_equal true, Sidekiq::Mailer::Worker.jobs.first['retry']
   end
 
   def test_enables_sidekiq_options_overriding
-    MailerInAnotherQueue.bye('test@test.com').deliver
+    MailerInAnotherQueue.bye('test@example.com').deliver
     assert_equal 'priority', Sidekiq::Mailer::Worker.jobs.first['queue']
     assert_equal 'false', Sidekiq::Mailer::Worker.jobs.first['retry']
   end
 
   def test_delivers_asynchronously
-    BasicMailer.welcome('test@test.com').deliver
+    BasicMailer.welcome('test@example.com').deliver
     assert_equal 1, Sidekiq::Mailer::Worker.jobs.size
     assert_equal 0, ActionMailer::Base.deliveries.size
   end
 
   def test_can_deliver_now
-    BasicMailer.welcome('test@test.com').deliver!
+    BasicMailer.welcome('test@example.com').deliver!
     assert_equal 1, ActionMailer::Base.deliveries.size
   end
 
-  def test_realy_delivers_email_when_performing_worker_job
-    Sidekiq::Mailer::Worker.new.perform('BasicMailer', 'welcome', 'test@test.com')
+  def test_really_delivers_email_when_performing_worker_job
+    Sidekiq::Mailer::Worker.new.perform('BasicMailer', 'welcome', 'test@example.com')
     assert_equal 1, ActionMailer::Base.deliveries.size
   end
 
   def test_delivers_synchronously_if_running_in_a_excluded_environment
     Sidekiq::Mailer.excluded_environments = [:test]
-    BasicMailer.welcome('test@test.com').deliver
+    BasicMailer.welcome('test@example.com').deliver
     assert_equal 0, Sidekiq::Mailer::Worker.jobs.size
     assert_equal 1, ActionMailer::Base.deliveries.size
+  end
+
+  def test_does_not_ignore_interceptors_when_delivering_synchronously
+    BasicMailer.welcome('foo@example.com').deliver!
+    assert_equal 0, ActionMailer::Base.deliveries.size
+  end
+
+  def test_does_not_ignore_interceptors_when_delivering_asynchronously
+    Sidekiq::Mailer::Worker.new.perform('BasicMailer', 'welcome', 'foo@example.com')
+    assert_equal 0, ActionMailer::Base.deliveries.size
   end
 end


### PR DESCRIPTION
See https://github.com/mikel/mail/blob/master/lib/mail/message.rb#L240

Also fixed a typo and used the reserved example.com in tests. http://tools.ietf.org/html/rfc2606
