### PR TITLE
[DocFix] Default queue of sidekiq mailer is mailer

### DIFF
--- a/lib/sidekiq_mailer.rb
+++ b/lib/sidekiq_mailer.rb
@@ -36,7 +36,7 @@ module Sidekiq
       # Allows customization for this type of Worker.
       # Legal options:
       #
-      #   :queue - use a named queue for this Worker, default 'default'
+      #   :queue - use a named queue for this Worker, default 'mailer'
       #   :retry - enable the RetryJobs middleware for this Worker, default *true*
       #   :timeout - timeout the perform method after N seconds, default *nil*
       #   :backtrace - whether to save any error backtrace in the retry payload to display in web UI,


### PR DESCRIPTION
In the comment it was mention that by default the queue would be default. But the default option mentioned in code is `mailer`. So corrected the documentation. 
