### PR TITLE
Sidekiq::Mailer::Proxy.respond_to_missing? to complement method_missing

### DIFF
--- a/lib/sidekiq_mailer/proxy.rb
+++ b/lib/sidekiq_mailer/proxy.rb
@@ -28,6 +28,10 @@ class Sidekiq::Mailer::Proxy
     actual_message.send(method_name, *args)
   end
 
+  def respond_to_missing?(method_name, include_private=false)
+    actual_message.respond_to?(method_name, include_private) || super
+  end
+
   def to_sidekiq
     params = {
       'class' => Sidekiq::Mailer::Worker,


### PR DESCRIPTION
`respond_to_missing?` should usually be defined when `method_missing`. Both are natural on this Proxy object.

I recently rolled out Sidekiq::Mailer (0.0.8) and found our email previews (via ActionMailer::Preview) broke. Turns out [Rails::MailersController uses respond_to? in that previewing pipeline](https://github.com/rails/rails/blob/master/railties/lib/rails/mailers_controller.rb#L29). Monkey-patching this hunk restores previews in our rails project.

Why `respond_to_missing?` and not `respond_to?`? Implementing the former retains functionality of `Object.method` whereas the latter does not.
